### PR TITLE
pkg: add repo details to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
   ],
   "author": "Jeremy Albright",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Js-Brecht/babel-plugin-tsconfig-paths"
+  },
+  "homepage": "https://github.com/Js-Brecht/babel-plugin-tsconfig-paths",
+  "bugs": {
+    "url": "https://github.com/Js-Brecht/babel-plugin-tsconfig-paths/issues"
+  },
   "peerDependencies": {
     "@babel/core": "^7.9.0"
   },


### PR DESCRIPTION
## Summary

add repository, homepage, and bugs fields

## Details

- without these fields, the [NPM page](https://www.npmjs.com/package/babel-plugin-tsconfig-paths) effectively has no link to the source code, which could feel a bit sus
  - but the source code is right here on GitHub! so just link them together for clarity / explicitness
    
## Review Notes

I did try to loosely follow the fields you had in some of your [other repos](https://github.com/Js-Brecht/gatsby-plugin-atl/blob/59924e756edc5eca3cd36ab8aeffa1f4a9ae9893/package.json#L8) to hopefully go with your preferences/style